### PR TITLE
Fix missing SafeGoogleFont helper

### DIFF
--- a/utils.dart
+++ b/utils.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+TextStyle SafeGoogleFont(
+  String font,
+  {double fontSize = 14,
+  FontWeight fontWeight = FontWeight.w400,
+  double height = 1,
+  Color color = Colors.black,
+  TextDecoration decoration = TextDecoration.none,
+  }) {
+  return GoogleFonts.getFont(
+    font,
+    fontSize: fontSize,
+    fontWeight: fontWeight,
+    height: height,
+    color: color,
+    decoration: decoration,
+  );
+}


### PR DESCRIPTION
## Summary
- add utils.dart containing SafeGoogleFont helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68595f8ec378832b853f93b42110ed84